### PR TITLE
Add gnatcoll-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ A curated list of awesome resources and other links related to the Ada and SPARK
 - [gnatcoll-core](https://github.com/AdaCore/gnatcoll-core) - This is the core module of the GNAT Components Collection
 - [gnatcoll-bindings](https://github.com/AdaCore/gnatcoll-bindings) - This is the bindings module of the GNAT Components Collection
 - [gnatcoll-db](https://github.com/AdaCore/gnatcoll-db) - This is the DB module of the GNAT Components Collection
+- [gnatcoll-json](https://github.com/persan/gnatcoll-json) - This is a set of helpers for writing JSON-intefaces it contains JSON parses for most of the Ada runtime components.
 
 #### Distributed
 - [poly-orb](https://github.com/AdaCore/PolyORB) - PolyORB provides a uniform solution to build distributed applications relying either on middleware standards


### PR DESCRIPTION
A helper library to write JSON interfaces using the standard Ada runtimes.
Ada.Containers.* and alike.

I