### PR TITLE
Remove github.com/AdaCore/embedded-runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 ## Runtimes
 - [generic-ada-runtime](https://github.com/Componolit/ada-runtime) - A downsized Ada runtime which can be adapted to different platforms.
 - [bb-runtimes](https://github.com/AdaCore/bb-runtimes) - GNAT bare metal board support package (BSP).
-- [embedded-runtimes](https://github.com/AdaCore/embedded-runtimes) - Runtimes that add support for various boards to the GNAT GPL compiler for ARM.
 - [avr-ada](https://sourceforge.net/projects/avr-ada) - GNAT for 8-bit AVR microcontrollers.
 
 ## OS and Kernels


### PR DESCRIPTION
This repository is now deprecated and replaced by bb-runtimes.