### PR TITLE
Add AdaML

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ lanugage.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [automate](https://github.com/Blady-Com/Automate) - Finite-state machine generator.
 - [ajunitgen](https://github.com/mosteo/ajunitgen) - Generator of JUnit-compatible XML reports in Ada.
 
+#### UML
+- [AdaML](https://github.com/rocher/AdaML) - Ada-tailored UML Modeling Language.
+
 ## Libraries
 
 #### Math


### PR DESCRIPTION
This is a small toll I've just released to draw Ada-tailored UML diagrams with specific emphasis in Ada characteristics.
Couldn't found anything referring UML, so I'm not quite sure if the location of the AdaML entry in the README.md file is the most appropriate one.