### PR TITLE
Use GitHub mirror for Smart_Pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ lanugage.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [ada-ga](https://github.com/frett27/Ada-GA) - Genetic Algorithm Implementation for Ada.
 - [ada-sodoku](https://github.com/frett27/Ada-Sodoku) - Small Library for Sodoku grid solving / finding.
 - [sl3p](https://github.com/jklmnn/sl3p) - Simple Layer 3 Protocol.
-- [smart-pointers](http://www.christ-usch-grein.homepage.t-online.de/Ada/Smart_Pointers.html) - A package providing a reference-counted access type Smart_Pointer.
+- [smart-pointers](https://github.com/alire-project/smart_pointers) - A package providing a reference-counted access type Smart_Pointer.
 - [marsaglia-random-number-generator](http://www.christ-usch-grein.homepage.t-online.de/Ada/Marsaglia.html) - Ada implementation of the algorithm developed by George Marsaglia, Supercomputer Computations Research Institute, Florida State University.
 - [hungarian-algorithm](https://github.com/fastrgv/HungarianAlgorithm) - Hungarian Algorithm implementation in Ada.
 - [sal](http://www.stephe-leake.org/ada/sal.html) - SAL (Stephe's Ada Library).


### PR DESCRIPTION
The original link to the Smart_Pointers library is dead ("Host not found"). Change it to the GitHub mirror of the Alire project.