### PR TITLE
Add BLAKE2S to the Cryptography category

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [xxhash-ada](https://github.com/lyarbean/xxhash-ada) - Extremely fast non-cryptographic Hash algorithm, xxhash is working at speeds close to RAM limits.
 - [libsodium-ada](https://github.com/jrmarino/libsodium-ada) - A secure cryptographic library (libsodium for Ada).
 - [ada-libsecret](https://github.com/stcarrez/ada-libsecret) - Ada Binding for the libsecret library.
+- [blake2s](https://github.com/lkujaw/blake2s) - SPARK83 implementation of the BLAKE2s hash function.
 
 #### Compression
 - [zip-ada](https://github.com/zertovitch/zip-ada) - Zip-Ada is a programming library for dealing with the Zip compressed archive file format.


### PR DESCRIPTION
Hello,

BLAKE2S (and B2SSUM) are already available as Alire crates. Let me know if you have any questions/concerns.

Thanks, Lev