### PR TITLE
Update the Steam Sky link

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 - [ironclad](https://nongnu.org/ironclad) - A kernel for several architectures striving for POSIX compatibility, used on several distributions like [Gloire](https://github.com/streaksu/Gloire).
 
 ## Games
-- [steamsky](https://thindil.github.io/steamsky) - Roguelike in sky with a steampunk setting.
+- [steamsky](https://www.laeran.pl/repositories/steamsky) - Roguelike in sky with a steampunk setting.
 - [unity-ada-tetris](https://blog.adacore.com/unity-ada) - Tetris, in Ada, for the Unity game engine.
 - [tictactoe](https://github.com/AdaCore/tictactoe) - A tictactoe game written and proven in SPARK/Ada.
 - [ada-gate](https://github.com/fastrgv/AdaGate) - AdaGate is a first-person 3D sokoban puzzle game within a Stargate / Portal fantasy setting for Windows, OS-X and Linux.


### PR DESCRIPTION
Updated because the current link is dead.