### PR TITLE
HAC and Byron are licensed under the MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 
 - [fsf-gnat](http://www.getadanow.com/) - Free Software Foundation compiler for the Ada programming language which forms part of the GNU Compiler Collection. It supports all versions of the language, i.e. Ada 2012, Ada 2005, Ada 95 and Ada 83.
 
-##### Other / unknown licence 
+##### MIT 
 
 - [hac](https://github.com/zertovitch/hac) - HAC Ada Compiler - a small, quick Ada compiler fully in Ada.
 - [byron](https://github.com/OneWingedShark/Byron) - The Byron project is a community-driven Ada compiler, toolchain, and IDE-system.


### PR DESCRIPTION
The source forge project page/website for HAC indicates that the project is licensed under the MIT license. The byron project is licensed under the MIT license in their github page.