### PR TITLE
Link checker: configuration to ignore adaic.org

### DIFF
--- a/.github/workflows/link_checker_config.json
+++ b/.github/workflows/link_checker_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www.adaic.org"
+    }
+  ]
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,7 @@ jobs:
           fetch-depth: 0
       - name: Check links
         uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: 'link_checker_config.json'
       - name: Awesome linter
         run: npx awesome-lint


### PR DESCRIPTION
Ignore adaic.org while it returns status 0.