### PR TITLE
Fix path to link_checker_config.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Check links
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          config-file: 'link_checker_config.json'
+          config-file: '.github/workflows/link_checker_config.json'
       - name: Awesome linter
         run: npx awesome-lint


### PR DESCRIPTION
Path is interpreted relative to the repository root and not to the containing directory.