### PR TITLE
⬆ Update: Add blackvideo-mini-player: a lightweight auxiliary video p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 ### Multimedia
 - [ada-3ds](https://github.com/AdaDoom3/Ada3DS) - A simple 3DS Max model renderer.
 - [canta](https://sourceforge.net/projects/canta/) - A tool to help to sing in tune.
+- [blackvideo-mini-player](https://github.com/BlackBlazent/blackvideo-mini-player) - A stand-alone lightweight auxiliary video player support for [``BlackVideo``](https://github.com/BlackBlazent/BlackVideo). 
 
 ### Automation
 - [acnc](https://github.com/Fabien-Chouteau/ACNC) - A G-code parser and CNC controller (in Ada).


### PR DESCRIPTION
# Add blackvideo-mini-player to the list

**Details**  
> Section 14: Application under `#Multimedia`

This entry adds **blackvideo-mini-player**, a lightweight, stand-alone auxiliary video player supporting **BlackVideo**.  
Repository: [https://github.com/BlackBlazent/blackvideo-mini-player](https://github.com/BlackBlazent/blackvideo-mini-player)
