### PR TITLE
Add Flyology runtime, libraries, and GNAT patchsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 #### GPL (with linking exception)
 
 - [fsf-gnat](https://github.com/alire-project/GNAT-FSF-builds/releases) - Free Software Foundation compiler for the Ada programming language which forms part of the GNU Compiler Collection. It supports all versions of the language, i.e. Ada 2022, Ada 2012, Ada 2005, Ada 95 and Ada 83.
+- [gnat-patches](https://github.com/flyology-ada/gnat-patches) - Curated GCC/GNAT patchsets against checksum-pinned upstream sources, each backed by an executable regression, published as patched native toolchain builds for GCC 13 through 16.
 
 #### MIT
 
@@ -294,9 +295,11 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 - [ada-runtime](https://github.com/Componolit/ada-runtime) - A downsized Ada runtime which can be adapted to different platforms.
 - [cortex-gnat-rts](https://github.com/simonjwright/cortex-gnat-rts) - This package includes GNAT Ada Run Time Systems (RTSs) based on FreeRTOS and targeted at boards with Cortex-M0, M3, -M4, -M4F MCUs.
 - [adawebpack](https://github.com/godunko/adawebpack) - GNAT RTL for WebAssembly and bindings for Web API.
+- [flyology](https://github.com/flyology-ada/flyology) - Experimental GNAT runtime extension for ordinary Ada tasking, adding task-aware I/O and an opt-in lightweight lane that runs designated tasks as fibers on shared event loops.
 
 [ada-runtime]: https://github.com/Componolit/ada-runtime
 [adawebpack]: https://github.com/godunko/adawebpack
+[flyology]: https://github.com/flyology-ada/flyology
 
 ## OS and Kernels
 - [m2os](https://m2os.unican.es/) - RTOS with simple tasking support for small microcontrollers.
@@ -369,6 +372,7 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 - [ncurses-ada95](https://invisible-island.net/ncurses/ncurses-Ada95.html) - Ada95 bindings for ncurses.
 - [linenoise-ada](https://git.sr.ht/~nytpu/linenoise-ada) - Bindings to the Linenoise line-editing library (patched to support UTF-8).
 - [areadline](https://github.com/samueltardieu/areadline) - Ada binding to the readline library.
+- [flyology-tui](https://github.com/flyology-ada/flyology-tui) - Typed, declarative terminal user-interface toolkit for Ada.
 
 ### 3D
 - [globe-3d](https://github.com/zertovitch/globe-3d) - GL Object Based Engine for 3D.
@@ -380,6 +384,7 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 - [ada-ado](https://github.com/stcarrez/ada-ado) - Ada Database Objects is an Ada05 library that provides object relational mapping to access a database in Ada05. The library supports PostgreSQL, MySQL, SQLite as databases. Most of the concepts developped for ADO come from the Java Hibernate ORM.
 - [ada-base](https://github.com/jrmarino/AdaBase) - Thick database bindings to MySQL, PostgreSQL and SQLite for Ada.
 - [apq-base](https://github.com/ada-apq/apq/) - APQ is a database interface library written in Ada95.
+- [flyology-postgres](https://github.com/flyology-ada/flyology-postgres) - Client and server primitives for the PostgreSQL frontend/backend protocol, built on [flyology] task-aware I/O.
 
 ### Web
 <!--lint disable awesome-spell-check-->
@@ -395,6 +400,7 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 - [swagger-ada](https://github.com/stcarrez/swagger-ada) - Ada support for Swagger codegen: OpenAPI Generator is a code generator that supports generation of API client libraries, server stubs and documentation automatically given an OpenAPI Spec.
 - [ews](https://github.com/simonjwright/ews) - Embedded Web Server is a web server construction kit, designed for embedded applications using the GNAT Ada compiler.
 - [matreshka](https://github.com/godunko/matreshka) - Framework to develop information systems consisting of five major components: League, XML processor, Web framework, SQL access, and the Modeling framework.
+- [flyology-http](https://github.com/flyology-ada/flyology-http) - HTTP/1.1 clients and servers with opt-in HTTP/2 and HTTP/3 engines and WebSocket support, built on [flyology] task-aware I/O.
 
 [matreshka]: https://github.com/godunko/matreshka
 
@@ -492,6 +498,8 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [agpl](https://github.com/mosteo/agpl) - Ada General Purpose Library (Miscellaneous utilities, with a robotic flavor).
 - [az3](https://github.com/Componolit/AZ3) - Ada binding for Z3.
 - [chests](https://github.com/JeremyGrosser/chests) - Bounded containers for embedded systems.
+- [flyology-allocators](https://github.com/flyology-ada/flyology/tree/main/flyology_allocators) - Caller-owned buddy, best-fit, TLSF, and slab/span allocation algorithms with no hosted operating system dependency.
+- [flyology-cachelines](https://github.com/flyology-ada/flyology/tree/main/flyology_cachelines) - Cache-line-aware storage, ownership-aware groups, grouped arrays, and host cache queries.
 
 [ada-language-server]: https://github.com/AdaCore/ada_language_server
 
@@ -563,6 +571,8 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [ada-toml](https://github.com/pmderodat/ada-toml) - TOML parser for Ada.
 - [uri-ada](https://git.sr.ht/~nytpu/uri-ada) - URI and MIME parser & manipulation library.
 - [ada-libmagic](https://gitlab.com/stcarrez/ada-libmagic) - Magic Number Recognition Library Ada binding (libmagic (3)).
+- [flyology-iri](https://github.com/flyology-ada/flyology-http/tree/main/flyology_iri) - Allocation-conscious URI, IRI, and WHATWG URL parsing.
+- [flyology-rdf](https://github.com/flyology-ada/flyology-rdf) - RDF 1.2 terms, streaming Turtle, TriG, N-Triples and N-Quads parsing, RDFC-1.0 dataset canonicalization, Notation3, and SPARQL 1.1 query syntax.
 
 [ada-toml]: https://github.com/pmderodat/ada-toml
 
@@ -579,6 +589,7 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [adare-net](https://gitlab.com/daresoft/network/adare_net) - This is a small, portable and easy to use Ada network lib. It supports ipv4 ipv6 udp and tcp, and can 'listen' with ipv6, too.
 - [pcsc-ada](https://www.codelabs.ch/pcscada) - PCSC/Ada provides a thick Ada binding to PC/SC-middleware. The library allows programs written in Ada to communicate with smart cards using the SCard API.
 - [coap-spark](https://github.com/mgrojo/coap_spark) - A formally verified implementation of CoAP, the Constrained Application Protocol.
+- [flyology-quic](https://github.com/flyology-ada/flyology-http/tree/main/flyology_quic) - Experimental bounded QUIC transport with protocol state, streams, loss recovery, and congestion control.
 
 ### Chatting and Communication
 - [axmpp](https://github.com/coopht/axmpp) - With the AXMPP library you can connect to a Jabber server to send and receive messages.
@@ -611,6 +622,7 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [opencl-ada](https://github.com/flyx/OpenCLAda) - An Ada binding for the OpenCL host API.
 - [boehmgc-ada](https://github.com/ytomino/boehmgc-ada) - Ada binding to the Boehm-Demers-Weiser conservative garbage collector.
 - [ada-bfd](https://github.com/stcarrez/ada-bfd) - An Ada binding for the GNU Binutils BFD library. It allows to read binary ELF, COFF files by using the GNU BFD.
+- [flyology-simd](https://github.com/flyology-ada/flyology-simd) - Portable, strongly typed SIMD foundations for Ada.
 
 ### Sound
 - [opus-ada](https://github.com/onox/opus-ada) - Ada 2012 bindings for the Opus audio codec.
@@ -643,6 +655,8 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [macos-sdks-vs-gcc](https://github.com/simonjwright/macos-sdks-vs-gcc) - Provides GCC 'specs' files to cope with SDK policy changes.
 - [ux-strings](https://github.com/Blady-Com/UXStrings) - Unicode extended strings.
 - [getopt-ada](https://git.sr.ht/~nytpu/getopt-ada) - Portable implementation of getopt(3) in Ada.
+- [flyology-bench](https://github.com/flyology-ada/flyology/tree/main/flyology_bench) - Adaptive microbenchmarking with balanced comparisons, diagnostics, baselines, and machine-readable reports.
+- [flyology-debug](https://github.com/flyology-ada/flyology/tree/main/flyology_debug) - Bounded in-memory tracing, producer shards, retained batches, and persistent gauges.
 
 ### Robotics
 - [rclada](https://github.com/ada-ros/rclada) - Ada client library for ROS2/RCL.
@@ -656,6 +670,7 @@ language.  It is loosely modelled after JUnit and some ideas from AUnit.
 - [inotify-ada](https://github.com/onox/inotify-ada) - An Ada 2012 library for monitoring filesystem events using Linux' inotify API.
 - [dl-ada](https://github.com/mosteo/dl-ada) - Minimal binding to libdl.
 - [suid-helper](https://gitlab.com/mockturtle/suid-helper) - Small Ada library that helps in writing safer suid programs.
+- [flyology-numa](https://github.com/flyology-ada/flyology/tree/main/flyology_numa) - Memory-node topology reporting, memory placement on a chosen node, and node-bound storage pools.
 
 ### Windows and .NET
 - [win32ada](https://github.com/AdaCore/win32ada) - Ada API to the Windows library.


### PR DESCRIPTION
Adds [Flyology](https://flyology.org/), an experimental systems programming project for Ada, along with its libraries and its GNAT patchset repository.

Flyology Runtime is a GNAT runtime extension for ordinary Ada tasking. Undesignated tasks stay native on their pthreads; explicitly designated lightweight tasks run cooperatively as fibers on shared event-loop threads. Both lanes keep rendezvous, protected objects, exceptions, task activation, masters, and normal synchronous control flow — there is no `async` dialect. The remaining entries are separate libraries: a few build on the runtime's task-aware I/O, most are standalone and can be adopted without it.

Each entry is placed in the section matching its topic rather than grouped in one place:

| Section | Entry |
| --- | --- |
| Compilers → Open source → GPL (with linking exception) | `gnat-patches` |
| Runtimes | `flyology` |
| Frameworks → Terminal User Interface | `flyology-tui` |
| Frameworks → Database | `flyology-postgres` |
| Frameworks → Web | `flyology-http` |
| Libraries → Algorithms, Containers and Protocols | `flyology-allocators`, `flyology-cachelines` |
| Libraries → Format Readers, Writers and Checkers | `flyology-iri`, `flyology-rdf` |
| Libraries → Networking and Communication Middleware | `flyology-quic` |
| Libraries → General Purpose Computing | `flyology-simd` |
| Libraries → Utilities | `flyology-bench`, `flyology-debug` |
| Libraries → Linux and POSIX | `flyology-numa` |

A `[flyology]` reference definition is added beside the existing `[adawebpack]` one, so the HTTP and Postgres entries can link back to the runtime the way `[matreshka]` and `[gnoga]` are used elsewhere in the list.

All libraries are MIT OR Apache-2.0 and packaged for Alire. `gnat-patches` publishes patched native GNAT toolchain builds for GCC 13 through 16, each patch applying to checksum-pinned upstream sources and backed by an executable regression.

Checks run locally before opening this: `npx awesome-lint` reports no findings beyond what pristine `master` already reports in the same environment, and all 14 added links return 200.

Happy to move or drop any of these. The two placements I was least sure about are `flyology-bench` (a benchmarking harness, currently under Libraries → Utilities, though Frameworks → Unit Test, Testing may suit it better) and `gnat-patches` (it ships toolchain builds like `fsf-gnat`, but it is fundamentally a patchset repository, so Tools → DevOps is a defensible alternative).
