### PR TITLE
Add ipfs: IPFS client library (CID, CAR, trustless gateway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ A curated list of awesome resources related to the Ada and SPARK programming lan
 
 ### Distributed
 - [poly-orb](https://github.com/AdaCore/PolyORB) - PolyORB provides a uniform solution to build distributed applications relying either on middleware standards.
+- [ipfs](https://github.com/kokhlo/ipfs) - IPFS client library: CID/multihash/multibase, CAR archives with block verification, trustless HTTP gateway client.
 
 ### Graphical User Interface
 - [gnoga](https://sourceforge.net/projects/gnoga/) - The GNU Omnificent GUI for Ada.


### PR DESCRIPTION
Adds [ipfs](https://github.com/kokhlo/ipfs) — a native IPFS client library for Ada:

- CID v0/v1 parse/encode/convert, multihash, multibase (base32/base58btc)
- CAR v1 archive reader with per-block hash verification
- Trustless HTTP gateway client (application/vnd.ipld.car)
- Pure Ada, zero dependencies (SHA-256 included), MIT
- 137 unit tests, CI on ubuntu/macos, E2E verified against kubo 0.43

Placed under **Distributed** (next to poly-orb). Alire index inclusion is in review (alire-project/alire-index#2117).